### PR TITLE
Add sender's network and address to the header.sender object

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -478,6 +478,10 @@ class Client extends EventEmitter {
     }
     header.apduType = baApdu.getDecodedType(buffer, offset);
     header.expectingReply = !!(result.funct & baEnum.NpduControlBit.EXPECTING_REPLY);
+    if (result.source) {
+      header.sender.net = result.source.net;
+      header.sender.adr = result.source.adr;
+    }
     this._handlePdu(buffer, offset, msgLength, header);
   }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -567,7 +567,10 @@ class Client extends EventEmitter {
   /**
    * The whoIs command discovers all BACNET devices in a network.
    * @function bacnet.whoIs
-   * @param {string} receiver - IP address of the target device.
+   * @param {string|object} receiver - IP address of the target device.
+   * @param {string} receiver.address - IP address of the target device.
+   * @param {number=} receiver.net - Network number of the target device.
+   * @param {Array.<number>=} receiver.adr - Bacnet address of the target device.
    * @param {object=} options
    * @param {number=} options.lowLimit - Minimal device instance number to search for.
    * @param {number=} options.highLimit - Maximal device instance number to search for.
@@ -577,6 +580,10 @@ class Client extends EventEmitter {
    * const client = new bacnet();
    *
    * client.whoIs();
+   *
+   * // to search for devices, including virtual, on all networks
+   * client.whoIs({net: 0xFFFF});
+   *
    */
   whoIs(receiver, options) {
     if (!options) {

--- a/lib/services/i-am.js
+++ b/lib/services/i-am.js
@@ -14,7 +14,7 @@
  *
  * client.on('iAm', (msg) => {
  *   console.log(
- *     'address: ', msg.header.address,
+ *     'sender: ', msg.header.sender,
  *     ' - deviceId: ', msg.payload.deviceId,
  *     ' - maxApdu: ', msg.payload.maxApdu,
  *     ' - segmentation: ', msg.payload.segmentation,


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guide](https://github.com/fh1ch/node-bacstack/blob/master/CONTRIBUTING.md).
- [x] My commit messages reference affected issues and mention breaking changes if applicable.
- [ ] I've updated / wrote inline documentation for the source code affected by my changes.
- [ ] All mandatory CI checks have passed (see when Pull Request has been submitted).

### What does this Pull Request do

- Adds the sender's network and BACnet address to the header while processing the NPDU (if they are provided), making it easy to send requests to virtual devices using the header.sender as the receiver. It also allows us to easily see and differentiate messages from multiple devices on the same IP.
- Updated the docs for client.whoIs() and the iAm event to reflect the current codebase.

Example of an iAm event if the message contains source address information:
```json
{
  "len": 2,
  "type": 16,
  "service": 0,
  "header": {
    "func": 10,
    "sender": {
      "address": "172.16.0.50",
      "forwardedFrom": null,
      "net": 9,
      "adr": [
        128,
        0,
        0,
        11,
        3,
        0
      ]
    },
    "apduType": 16,
    "expectingReply": false,
    "confirmedService": false
  },
  "payload": {
    "len": 0,
    "deviceId": 957900,
    "maxApdu": 1476,
    "segmentation": 3,
    "vendorId": 971
  }
}
```
